### PR TITLE
Fixed VAST tracking bug where if the video started muted, unmute would not be triggered the first time

### DIFF
--- a/src/scripts/plugin/videojs.vast.vpaid.js
+++ b/src/scripts/plugin/videojs.vast.vpaid.js
@@ -276,7 +276,7 @@ module.exports = function VASTPlugin(options) {
 
     player.vast.vastResponse = vastResponse;
     logger.debug ("calling adIntegrator.playAd() with vastResponse:", vastResponse);
-    player.vast.adUnit = adIntegrator.playAd(vastResponse, callback);
+    player.vast.adUnit = adIntegrator.playAd(vastResponse, callback, settings.clickUrl);
 
     /*** Local functions ****/
     function addAdsLabel() {


### PR DESCRIPTION
Fixed VAST tracking bug where if the video started muted, unmute would not be triggered the first time

Added `clickUrl` to settings